### PR TITLE
Carbon Five also has its own Slack group

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@
 - [LearnToCodeLA](https://learntocodela.slack.com/)
 - [TechTinx](https://techtinos.slack.com/)
 - [Santa Monica Haskell](https://santamonicahaskell.slack.com/)
+- [Carbon Five Hack Nights](https://carbonfivehacknights-slack.herokuapp.com/)
 
 ## Google Groups
 


### PR DESCRIPTION
Just learned @rudyjahchan's carbon 5 la meetup has its own slack group so I added the invite link to the README.